### PR TITLE
fix: add file ignore rule

### DIFF
--- a/packages/vite-plugin-gen-temp/src/copySrcMd.ts
+++ b/packages/vite-plugin-gen-temp/src/copySrcMd.ts
@@ -17,13 +17,17 @@ export async function copySrcMd(
   const globSource = `${srcDir}/**/*.md`;
 
   if (initial) {
-    const mdFiles = await fg(globSource, { dot: true, cwd: process.cwd() });
+    const mdFiles = await fg(globSource, {
+      dot: true,
+      cwd: process.cwd(),
+      ignore: ['**/node_modules/**'],
+    });
     await Promise.all(mdFiles.map(copyFile));
   } else {
     chokidar
       .watch(globSource, {
         cwd: process.cwd(),
-        ignored: [],
+        ignored: [/node_modules/],
         ignoreInitial: true,
       })
       .on('change', copyFile)


### PR DESCRIPTION
`monorepo`场景下，过滤掉子包`node_modules`中的`md`文件