### PR TITLE
fix: render failed when use demo component with a newline

### DIFF
--- a/packages/md-demo-plugins/src/plugin-demo-block.ts
+++ b/packages/md-demo-plugins/src/plugin-demo-block.ts
@@ -13,7 +13,7 @@ export function demoBlockPlugin(md: MarkdownRenderer) {
       const token = tokens[idx];
       const content = token.content.trim();
 
-      if (!content.startsWith(`<${DemoTag} `)) {
+      if (!(content.startsWith(`<${DemoTag} `) || content.startsWith(`<${DemoTag}\n`))) {
         return defaultRender!(tokens, idx, options, env, self);
       }
 

--- a/packages/md-demo-plugins/src/utils.ts
+++ b/packages/md-demo-plugins/src/utils.ts
@@ -47,7 +47,7 @@ export function genDemoByCode(
 
   while (true) {
     demoName = `demo-${fenceIndex++}.vue`;
-    demoPath = join(dirname(path), demoName);
+    demoPath = join(dirname(path), 'dist', demoName);
     if (!fsExtra.existsSync(demoPath)) {
       break;
     }

--- a/packages/vite-plugin-gen-api-doc/src/plugin-api.ts
+++ b/packages/vite-plugin-gen-api-doc/src/plugin-api.ts
@@ -14,7 +14,7 @@ export function demoBlockPlugin(md: MarkdownRenderer) {
     const token = tokens[idx];
     const content = token.content.trim();
 
-    if (!content.startsWith(`<${ApiTag} `)) {
+    if (!(content.startsWith(`<${ApiTag} `) || content.startsWith(`<${ApiTag}\n`))) {
       return defaultRender!(tokens, idx, ...args);
     }
 


### PR DESCRIPTION
render correctly:

```
<demo src="../demo.vue" title="Demo block" desc="use demo"></demo>
```

but when there is a newline rather than space  after `<demo`, it  won't be rendered

```
<demo
	src="../demo.vue"
	title="Demo block"
	desc="use demo"
></demo>
```